### PR TITLE
remove schema timestamps from Groups and GroupPermissions

### DIFF
--- a/src/FluxBB/Migrations/Install/GroupPermissions.php
+++ b/src/FluxBB/Migrations/Install/GroupPermissions.php
@@ -41,8 +41,6 @@ class GroupPermissions extends Migration
 			$table->integer('group_id')->unsigned();
 			$table->string('name', 50);
 			$table->boolean('value');
-			
-			$table->timestamps();
 		});
 	}
 

--- a/src/FluxBB/Migrations/Install/Groups.php
+++ b/src/FluxBB/Migrations/Install/Groups.php
@@ -41,8 +41,6 @@ class Groups extends Migration
 			$table->string('title', 50)->default('');
 			
 			$table->integer('parent_group_id')->unsigned()->nullable();
-
-			$table->timestamps();
 		});
 	}
 


### PR DESCRIPTION
The timestamps causes inserts of Groups and GroupPermissions to fail in strict mode on MySQL and on SQLite

```
SQLSTATE[23000]: Integrity constraint violation: 19 groups.created_at may not be NULL (SQL: insert into "groups" ("id", "title") values (?, ?)) (Bindings: array ( 0 => 1, 1 => 'seed_data.administrators', )) 
```

Either the timestamp fields need to be removed (they aren't being used by the models) or the models should have them added like so:

```
public $timestamps = array('created_at', 'updated_at');
```
