### PR TITLE
Namespace have to be on first line

### DIFF
--- a/src/FluxBB/Models/Base.php
+++ b/src/FluxBB/Models/Base.php
@@ -1,7 +1,4 @@
-
-<?php
-
-namespace FluxBB\Models;
+<?php namespace FluxBB\Models;
 
 use Illuminate\Database\Eloquent\Model;
 


### PR DESCRIPTION
Installer drops error because the namespace line isn't in the first row.
