### PR TITLE
Set connection for FluxBB tables - not globally

### DIFF
--- a/src/FluxBB/Models/Base.php
+++ b/src/FluxBB/Models/Base.php
@@ -13,6 +13,7 @@ class Base extends Model
 
     protected $errors = array();
 
+    protected $connection = 'fluxbb';
 
     public function valid()
     {

--- a/src/FluxBB/Models/Config.php
+++ b/src/FluxBB/Models/Config.php
@@ -21,7 +21,7 @@ class Config
         }
 
         static::$data = static::$original = Cache::remember('fluxbb.config', 24 * 60, function () {
-            $data = DB::table('config')->get();
+            $data = DB::connection('fluxbb')->table('config')->get();
             $cache = array();
 
             foreach ($data as $row) {
@@ -87,17 +87,17 @@ class Config
         }
 
         if (!empty($insert_values)) {
-            DB::table('config')->insert($insert_values);
+            DB::connection('fluxbb')->table('config')->insert($insert_values);
         }
 
         foreach ($changed as $name => $value) {
-            DB::table('config')->where('conf_name', '=', $name)->update(array('conf_value' => $value));
+            DB::connection('fluxbb')->table('config')->where('conf_name', '=', $name)->update(array('conf_value' => $value));
         }
 
         // Deleted keys
         $deleted_keys = array_keys(array_diff_key(static::$original, static::$data));
         if (!empty($deleted_keys)) {
-            DB::table('config')->whereIn('conf_name', $deleted_keys)->delete();
+            DB::connection('fluxbb')->table('config')->whereIn('conf_name', $deleted_keys)->delete();
         }
 
         // No need to cache old values anymore

--- a/src/FluxBB/Models/ConfigRepository.php
+++ b/src/FluxBB/Models/ConfigRepository.php
@@ -28,7 +28,7 @@ class ConfigRepository implements ConfigRepositoryInterface
         }
 
         $this->data = $this->original = $this->cache->remember('fluxbb.config', 24 * 60, function () {
-            $data = DB::table('config')->get();
+            $data = DB::connection('fluxbb')->table('config')->get();
             $cache = array();
 
             foreach ($data as $row) {
@@ -81,17 +81,17 @@ class ConfigRepository implements ConfigRepositoryInterface
         }
 
         if (!empty($insert_values)) {
-            DB::table('config')->insert($insert_values);
+            DB::connection('fluxbb')->table('config')->insert($insert_values);
         }
 
         foreach ($changed as $name => $value) {
-            DB::table('config')->where('conf_name', '=', $name)->update(array('conf_value' => $value));
+            DB::connection('fluxbb')->table('config')->where('conf_name', '=', $name)->update(array('conf_value' => $value));
         }
 
         // Deleted keys
         $deleted_keys = array_keys(array_diff_key($this->original, $this->data));
         if (!empty($deleted_keys)) {
-            DB::table('config')->whereIn('conf_name', $deleted_keys)->delete();
+            DB::connection('fluxbb')->table('config')->whereIn('conf_name', $deleted_keys)->delete();
         }
 
         // No need to cache old values anymore

--- a/src/start.php
+++ b/src/start.php
@@ -2,7 +2,6 @@
 
 if (FluxBB\Core::isInstalled()) {
     Config::set('database.connections.fluxbb', Config::get('fluxbb.database'));
-    DB::setDefaultConnection('fluxbb');
 }
 
 // Load our helpers (composers, macros, validators etc.)


### PR DESCRIPTION
FluxBB sets the default database connection, which affects other modules and applications.

Is it better to set the connection for just the FlubBB tables?
